### PR TITLE
Supporting warding against multiple class references

### DIFF
--- a/Ward.xcodeproj/project.pbxproj
+++ b/Ward.xcodeproj/project.pbxproj
@@ -10,9 +10,10 @@
 		A018AC262127094E00259F42 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = A018AC252127094E00259F42 /* README.md */; };
 		A01CCA9E212D3EB00022ADD3 /* Ward.podspec in Resources */ = {isa = PBXBuildFile; fileRef = A01CCA9D212D3EB00022ADD3 /* Ward.podspec */; };
 		A0BC75FB212672D500A47FD7 /* Ward.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A0BC75F1212672D500A47FD7 /* Ward.framework */; };
-		A0BC7600212672D500A47FD7 /* WardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0BC75FF212672D500A47FD7 /* WardTests.swift */; };
+		A0BC7600212672D500A47FD7 /* FlatFunctionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0BC75FF212672D500A47FD7 /* FlatFunctionTests.swift */; };
 		A0BC760C212672E800A47FD7 /* Ward.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0BC760B212672E800A47FD7 /* Ward.swift */; };
 		A0BC760E2126731C00A47FD7 /* SampleClasses.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0BC760D2126731C00A47FD7 /* SampleClasses.swift */; };
+		A0CDED3F212DEEB800779017 /* CurriedFunctionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0CDED3E212DEEB800779017 /* CurriedFunctionTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -31,10 +32,11 @@
 		A0BC75F1212672D500A47FD7 /* Ward.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Ward.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A0BC75F5212672D500A47FD7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A0BC75FA212672D500A47FD7 /* WardTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WardTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		A0BC75FF212672D500A47FD7 /* WardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WardTests.swift; sourceTree = "<group>"; };
+		A0BC75FF212672D500A47FD7 /* FlatFunctionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlatFunctionTests.swift; sourceTree = "<group>"; };
 		A0BC7601212672D500A47FD7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A0BC760B212672E800A47FD7 /* Ward.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ward.swift; sourceTree = "<group>"; };
 		A0BC760D2126731C00A47FD7 /* SampleClasses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleClasses.swift; sourceTree = "<group>"; };
+		A0CDED3E212DEEB800779017 /* CurriedFunctionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurriedFunctionTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -88,7 +90,8 @@
 		A0BC75FE212672D500A47FD7 /* WardTests */ = {
 			isa = PBXGroup;
 			children = (
-				A0BC75FF212672D500A47FD7 /* WardTests.swift */,
+				A0BC75FF212672D500A47FD7 /* FlatFunctionTests.swift */,
+				A0CDED3E212DEEB800779017 /* CurriedFunctionTests.swift */,
 				A0BC760D2126731C00A47FD7 /* SampleClasses.swift */,
 				A0BC7601212672D500A47FD7 /* Info.plist */,
 			);
@@ -213,8 +216,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A0CDED3F212DEEB800779017 /* CurriedFunctionTests.swift in Sources */,
 				A0BC760E2126731C00A47FD7 /* SampleClasses.swift in Sources */,
-				A0BC7600212672D500A47FD7 /* WardTests.swift in Sources */,
+				A0BC7600212672D500A47FD7 /* FlatFunctionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Ward/Ward.swift
+++ b/Ward/Ward.swift
@@ -6,85 +6,175 @@
 //  Copyright © 2018 Mack Hasz and Swain Molster. All rights reserved.
 //
 
-// MARK: Flat function variants
+// MARK: - Flat Function Variants
 
-/* Void Output */
+// MARK: Void Output
 
-/**
- Wards a `function` based on the lifetime of an `object`. `object` will not be retained, and `function` will only be called if `object` is non-nil at call-time.
- */
-public func ward<Object: AnyObject>(_ object: Object, function: @escaping (Object) -> Void) -> () -> Void {
-    return { [weak object] in
-        guard let obj = object else { return }
-        function(obj)
+// MARK: + () -> Void
+
+public func ward<First: AnyObject>(_ first: First, function: @escaping (First) -> Void) -> () -> Void {
+    return { [weak first] in
+        guard let first = first else { return }
+        function(first)
     }
 }
 
-/**
- Wards a `function` based on the lifetime of an `object`. `object` will not be retained, and `function` will only be called if `object` is non-nil at call-time.
- */
-public func ward<Object: AnyObject, A>(_ object: Object, function: @escaping (Object, A) -> Void) -> (A) -> Void {
-    return { [weak object] a in
-        guard let obj = object else { return }
-        function(obj, a)
+public func ward<First: AnyObject, Second: AnyObject>(_ first: First, _ second: Second, function: @escaping (First, Second) -> Void) -> () -> Void {
+    return { [weak first, weak second] in
+        guard let first = first, let second = second else { return }
+        function(first, second)
     }
 }
 
-/**
- Wards a `function` based on the lifetime of an `object`. `object` will not be retained, and `function` will only be called if `object` is non-nil at call-time.
- */
-public func ward<Object: AnyObject, A, B>(_ object: Object, function: @escaping (Object, A, B) -> Void) -> (A, B) -> Void {
-    return { [weak object] a, b in
-        guard let obj = object else { return }
-        function(obj, a, b)
+public func ward<First: AnyObject, Second: AnyObject, Third: AnyObject>(_ first: First, _ second: Second, _ third: Third, function: @escaping (First, Second, Third) -> Void) -> () -> Void {
+    return { [weak first, weak second, weak third] in
+        guard let first = first, let second = second, let third = third else { return }
+        function(first, second, third)
     }
 }
 
-/**
- Wards a `function` based on the lifetime of an `object`. `object` will not be retained, and `function` will only be called if `object` is non-nil at call-time.
- */
-public func ward<Object: AnyObject, A, B, C>(_ object: Object, function: @escaping (Object, A, B, C) -> Void) -> (A, B, C) -> Void {
-    return { [weak object] a, b, c in
-        guard let obj = object else { return }
-        function(obj, a, b, c)
+// MARK: + (A) -> Void
+
+public func ward<First: AnyObject, A>(_ first: First, function: @escaping (First, A) -> Void) -> (A) -> Void {
+    return { [weak first] a in
+        guard let first = first else { return }
+        function(first, a)
     }
 }
 
-/* Generic Output */
-
-/**
- Wards a `function` based on the lifetime of an `object`, returing a `defaultValue` if `object` has deallocated. `object` will not be retained, and `function` will only be called if `object` is non-nil at call-time.
- */
-public func ward<Object: AnyObject, Z>(_ object: Object, else defaultValue: Z, function: @escaping (Object) -> Z) -> () -> Z {
-    return { [weak object] in
-        guard let obj = object else { return defaultValue }
-        return function(obj)
+public func ward<First: AnyObject, Second: AnyObject, A>(_ first: First, _ second: Second, function: @escaping (First, Second, A) -> Void) -> (A) -> Void {
+    return { [weak first, weak second] a in
+        guard let first = first, let second = second else { return }
+        function(first, second, a)
     }
 }
 
-/**
- Wards a `function` based on the lifetime of an `object`, returing a `defaultValue` if `object` has deallocated. `object` will not be retained, and `function` will only be called if `object` is non-nil at call-time.
- */
-public func ward<Object: AnyObject, A, Z>(_ object: Object, else defaultValue: Z, function: @escaping (Object, A) -> Z) -> (A) -> Z {
-    return { [weak object] a in
-        guard let obj = object else { return defaultValue }
-        return function(obj, a)
+public func ward<First: AnyObject, Second: AnyObject, Third: AnyObject, A>(_ first: First, _ second: Second, _ third: Third, function: @escaping (First, Second, Third, A) -> Void) -> (A) -> Void {
+    return { [weak first, weak second, weak third] a in
+        guard let first = first, let second = second, let third = third else { return }
+        function(first, second, third, a)
     }
 }
 
-/**
- Wards a `function` based on the lifetime of an `object`, returing a `defaultValue` if `object` has deallocated. `object` will not be retained, and `function` will only be called if `object` is non-nil at call-time.
- */
-public func ward<Object: AnyObject, A, B, Z>(_ object: Object, else defaultValue: Z, function: @escaping (Object, A, B) -> Z) -> (A, B) -> Z {
-    return { [weak object] a, b in
-        guard let obj = object else { return defaultValue }
-        return function(obj, a, b)
+// MARK: + (A, B) -> Void
+
+public func ward<First: AnyObject, A, B>(_ first: First, function: @escaping (First, A, B) -> Void) -> (A, B) -> Void {
+    return { [weak first] a, b in
+        guard let first = first else { return }
+        function(first, a, b)
     }
 }
 
-/**
- Wards a `function` based on the lifetime of an `object`, returing a `defaultValue` if `object` has deallocated. `object` will not be retained, and `function` will only be called if `object` is non-nil at call-time.
- */
+public func ward<First: AnyObject, Second: AnyObject, A, B>(_ first: First, _ second: Second, function: @escaping (First, Second, A, B) -> Void) -> (A, B) -> Void {
+    return { [weak first, weak second] a, b in
+        guard let first = first, let second = second else { return }
+        function(first, second, a, b)
+    }
+}
+
+public func ward<First: AnyObject, Second: AnyObject, Third: AnyObject, A, B>(_ first: First, _ second: Second, _ third: Third, function: @escaping (First, Second, Third, A, B) -> Void) -> (A, B) -> Void {
+    return { [weak first, weak second, weak third] a, b in
+        guard let first = first, let second = second, let third = third else { return }
+        function(first, second, third, a, b)
+    }
+}
+
+// MARK: + (A, B, C) -> Void
+
+public func ward<First: AnyObject, A, B, C>(_ first: First, function: @escaping (First, A, B, C) -> Void) -> (A, B, C) -> Void {
+    return { [weak first] a, b, c in
+        guard let first = first else { return }
+        function(first, a, b, c)
+    }
+}
+
+public func ward<First: AnyObject, Second: AnyObject, A, B, C>(_ first: First, _ second: Second, function: @escaping (First, Second, A, B, C) -> Void) -> (A, B, C) -> Void {
+    return { [weak first, weak second] a, b, c in
+        guard let first = first, let second = second else { return }
+        function(first, second, a, b, c)
+    }
+}
+
+public func ward<First: AnyObject, Second: AnyObject, Third: AnyObject, A, B, C>(_ first: First, _ second: Second, _ third: Third, function: @escaping (First, Second, Third, A, B, C) -> Void) -> (A, B, C) -> Void {
+    return { [weak first, weak second, weak third] a, b, c in
+        guard let first = first, let second = second, let third = third else { return }
+        function(first, second, third, a, b, c)
+    }
+}
+
+// MARK: Generic Output
+
+// MARK: + () -> Z
+
+public func ward<First: AnyObject, Z>(_ first: First, else defaultValue: Z, function: @escaping (First) -> Z) -> () -> Z {
+    return { [weak first] in
+        guard let first = first else { return defaultValue }
+        return function(first)
+    }
+}
+
+public func ward<First: AnyObject, Second: AnyObject, Z>(_ first: First, _ second: Second, else defaultValue: Z, function: @escaping (First, Second) -> Z) -> () -> Z {
+    return { [weak first, weak second] in
+        guard let first = first, let second = second else { return defaultValue }
+        return function(first, second)
+    }
+}
+
+public func ward<First: AnyObject, Second: AnyObject, Third: AnyObject, Z>(_ first: First, _ second: Second, _ third: Third, else defaultValue: Z, function: @escaping (First, Second, Third) -> Z) -> () -> Z {
+    return { [weak first, weak second, weak third] in
+        guard let first = first, let second = second, let third = third else { return defaultValue }
+        return function(first, second, third)
+    }
+}
+
+// MARK: + (A) -> Z
+
+public func ward<First: AnyObject, A, Z>(_ first: First, else defaultValue: Z, function: @escaping (First, A) -> Z) -> (A) -> Z {
+    return { [weak first] a in
+        guard let first = first else { return defaultValue }
+        return function(first, a)
+    }
+}
+
+public func ward<First: AnyObject, Second: AnyObject, A, Z>(_ first: First, _ second: Second, else defaultValue: Z, function: @escaping (First, Second, A) -> Z) -> (A) -> Z {
+    return { [weak first, weak second] a in
+        guard let first = first, let second = second else { return defaultValue }
+        return function(first, second, a)
+    }
+}
+
+public func ward<First: AnyObject, Second: AnyObject, Third: AnyObject, A, Z>(_ first: First, _ second: Second, _ third: Third, else defaultValue: Z, function: @escaping (First, Second, Third, A) -> Z) -> (A) -> Z {
+    return { [weak first, weak second, weak third] a in
+        guard let first = first, let second = second, let third = third else { return defaultValue }
+        return function(first, second, third, a)
+    }
+}
+
+// MARK: + (A, B) -> Z
+
+public func ward<First: AnyObject, A, B, Z>(_ first: First, else defaultValue: Z, function: @escaping (First, A, B) -> Z) -> (A, B) -> Z {
+    return { [weak first] a, b in
+        guard let first = first else { return defaultValue }
+        return function(first, a, b)
+    }
+}
+
+public func ward<First: AnyObject, Second: AnyObject, A, B, Z>(_ first: First, _ second: Second, else defaultValue: Z, function: @escaping (First, Second, A, B) -> Z) -> (A, B) -> Z {
+    return { [weak first, weak second] a, b in
+        guard let first = first, let second = second else { return defaultValue }
+        return function(first, second, a, b)
+    }
+}
+
+public func ward<First: AnyObject, Second: AnyObject, Third: AnyObject, A, B, Z>(_ first: First, _ second: Second, _ third: Third, else defaultValue: Z, function: @escaping (First, Second, Third, A, B) -> Z) -> (A, B) -> Z {
+    return { [weak first, weak second, weak third] a, b in
+        guard let first = first, let second = second, let third = third else { return defaultValue }
+        return function(first, second, third, a, b)
+    }
+}
+
+// MARK: + (A, B, C) -> Z
+
 public func ward<Object: AnyObject, A, B, C, Z>(_ object: Object, else defaultValue: Z, function: @escaping (Object, A, B, C) -> Z) -> (A, B, C) -> Z {
     return { [weak object] a, b, c in
         guard let obj = object else { return defaultValue }
@@ -92,10 +182,11 @@ public func ward<Object: AnyObject, A, B, C, Z>(_ object: Object, else defaultVa
     }
 }
 
-// MARK: - Curried function variants, for handling with Swift synthesized static class functions.
+// MARK: - Curried Function Variants
 
-/* Void Output */
+// MARK: Void Output
 
+// MARK: + () -> Void
 public func ward<Object: AnyObject>(_ object: Object, function: @escaping (Object) -> () -> Void) -> () -> Void {
     return { [weak object] in
         guard let object = object else { return }
@@ -103,6 +194,7 @@ public func ward<Object: AnyObject>(_ object: Object, function: @escaping (Objec
     }
 }
 
+// MARK: + (A) -> Void
 public func ward<Object: AnyObject, A>(_ object: Object, function: @escaping (Object) -> (A) -> Void) -> (A) -> Void {
     return { [weak object] a in
         guard let object = object else { return }
@@ -110,6 +202,7 @@ public func ward<Object: AnyObject, A>(_ object: Object, function: @escaping (Ob
     }
 }
 
+// MARK: + (A, B) -> Void
 public func ward<Object: AnyObject, A, B>(_ object: Object, function: @escaping (Object) -> (A, B) -> Void) -> (A, B) -> Void {
     return { [weak object] a, b in
         guard let object = object else { return }
@@ -117,6 +210,7 @@ public func ward<Object: AnyObject, A, B>(_ object: Object, function: @escaping 
     }
 }
 
+// MARK: + (A, B, C) -> Void
 public func ward<Object: AnyObject, A, B, C>(_ object: Object, function: @escaping (Object) -> (A, B, C) -> Void) -> (A, B, C) -> Void {
     return { [weak object] a, b, c in
         guard let object = object else { return }
@@ -124,8 +218,9 @@ public func ward<Object: AnyObject, A, B, C>(_ object: Object, function: @escapi
     }
 }
 
-/* Generic Output */
+// MARK: Generic Output
 
+// MARK: + () -> Z
 public func ward<Object: AnyObject, Z>(_ object: Object, else defaultValue: Z, function: @escaping (Object) -> () -> Z) -> () -> Z {
     return { [weak object] in
         guard let object = object else { return defaultValue }
@@ -133,6 +228,7 @@ public func ward<Object: AnyObject, Z>(_ object: Object, else defaultValue: Z, f
     }
 }
 
+// MARK: + (A) -> Z
 public func ward<Object: AnyObject, A, Z>(_ object: Object, else defaultValue: Z, function: @escaping (Object) -> (A) -> Z) -> (A) -> Z {
     return { [weak object] a in
         guard let object = object else { return defaultValue }
@@ -140,6 +236,7 @@ public func ward<Object: AnyObject, A, Z>(_ object: Object, else defaultValue: Z
     }
 }
 
+// MARK: + (A, B) -> Z
 public func ward<Object: AnyObject, A, B, Z>(_ object: Object, else defaultValue: Z, function: @escaping (Object) -> (A, B) -> Z) -> (A, B) -> Z {
     return { [weak object] a, b in
         guard let object = object else { return defaultValue }
@@ -147,6 +244,7 @@ public func ward<Object: AnyObject, A, B, Z>(_ object: Object, else defaultValue
     }
 }
 
+// MARK: + (A, B, C) -> Void
 public func ward<Object: AnyObject, A, B, C, Z>(_ object: Object, else defaultValue: Z, function: @escaping (Object) -> (A, B, C) -> Z) -> (A, B, C) -> Z {
     return { [weak object] a, b, c in
         guard let object = object else { return defaultValue }

--- a/Ward/Ward.swift
+++ b/Ward/Ward.swift
@@ -175,10 +175,24 @@ public func ward<First: AnyObject, Second: AnyObject, Third: AnyObject, A, B, Z>
 
 // MARK: + (A, B, C) -> Z
 
-public func ward<Object: AnyObject, A, B, C, Z>(_ object: Object, else defaultValue: Z, function: @escaping (Object, A, B, C) -> Z) -> (A, B, C) -> Z {
-    return { [weak object] a, b, c in
-        guard let obj = object else { return defaultValue }
-        return function(obj, a, b, c)
+public func ward<First: AnyObject, A, B, C, Z>(_ first: First, else defaultValue: Z, function: @escaping (First, A, B, C) -> Z) -> (A, B, C) -> Z {
+    return { [weak first] a, b, c in
+        guard let first = first else { return defaultValue }
+        return function(first, a, b, c)
+    }
+}
+
+public func ward<First: AnyObject, Second: AnyObject, A, B, C, Z>(_ first: First, _ second: Second, else defaultValue: Z, function: @escaping (First, Second, A, B, C) -> Z) -> (A, B, C) -> Z {
+    return { [weak first, weak second] a, b, c in
+        guard let first = first, let second = second else { return defaultValue }
+        return function(first, second, a, b, c)
+    }
+}
+
+public func ward<First: AnyObject, Second: AnyObject, Third: AnyObject, A, B, C, Z>(_ first: First, _ second: Second, _ third: Third, else defaultValue: Z, function: @escaping (First, Second, Third, A, B, C) -> Z) -> (A, B, C) -> Z {
+    return { [weak first, weak second, weak third] a, b, c in
+        guard let first = first, let second = second, let third = third else { return defaultValue }
+        return function(first, second, third, a, b, c)
     }
 }
 

--- a/WardTests/CurriedFunctionTests.swift
+++ b/WardTests/CurriedFunctionTests.swift
@@ -1,98 +1,17 @@
 //
-//  WardTests.swift
+//  CurriedFunctionTests.swift
 //  WardTests
 //
-//  Created by Mack Hasz and Swain Molster on 8/16/18.
-//  Copyright © 2018 Mack Hasz and Swain Molster. All rights reserved.
+//  Created by Swain Molster on 8/22/18.
+//  Copyright © 2018 Swain Molster. All rights reserved.
 //
 
 import XCTest
 @testable import Ward
 
-class WardTests: XCTestCase {
+class CurriedFunctionTests: XCTestCase {
     
-    func testGenericInAndOut() {
-        var sample: SampleClass? = SampleClass()
-        
-        let function: (String) -> Int = ward(sample.unsafelyUnwrapped, else: -1) { _, string in
-            return string.count
-        }
-        
-        XCTAssert(function("Test") == 4)
-        XCTAssert(function("TestTwo") == 7)
-        
-        sample = nil
-        
-        XCTAssert(function("Test") == -1)
-    }
-    
-    func testJustGenericIn() {
-        var counter: Int = 0
-        
-        var sample: SampleClass? = SampleClass()
-        
-        let function: (String) -> Void = ward(sample.unsafelyUnwrapped) { _, string in
-            counter += string.count
-        }
-        
-        XCTAssert(counter == 0)
-        
-        function("Test")
-        
-        XCTAssert(counter == 4)
-        
-        function("Tes")
-        
-        XCTAssert(counter == 7)
-        
-        sample = nil
-        
-        function("Test!")
-        
-        XCTAssert(counter == 7)
-    }
-    
-    func testJustGenericOut() {
-        var sample: SampleClass? = SampleClass()
-        
-        let function: () -> Bool = ward(sample.unsafelyUnwrapped, else: false) { _ in
-            return true
-        }
-        
-        XCTAssert(function() == true)
-        
-        sample = nil
-        
-        XCTAssert(function() == false)
-    }
-    
-    func testVoidToVoid() {
-        var counter = 0
-        
-        var sample: SampleClass? = SampleClass()
-        
-        let function: () -> Void = ward(sample.unsafelyUnwrapped) { _ in
-            counter += 1
-        }
-        
-        XCTAssert(counter == 0)
-        
-        function()
-        
-        XCTAssert(counter == 1)
-        
-        function()
-        
-        XCTAssert(counter == 2)
-        
-        sample = nil
-        
-        function()
-        
-        XCTAssert(counter == 2)
-    }
-    
-    // MARK: Testing curried variants w/ Void output
+    // MARK: Void Output
     
     func testCurryNoInputNoOutput() {
         var counter = 0
@@ -186,7 +105,7 @@ class WardTests: XCTestCase {
         XCTAssert(counter == 4)
     }
     
-    // MARK: Testing curried variants w/ generic output
+    // MARK: Generic Output
     
     func testCurryNoInputWithOutput() {
         var counter = 0

--- a/WardTests/FlatFunctionTests.swift
+++ b/WardTests/FlatFunctionTests.swift
@@ -1,0 +1,664 @@
+//
+//  FlatFunctionTests.swift
+//  WardTests
+//
+//  Created by Mack Hasz and Swain Molster on 8/16/18.
+//  Copyright © 2018 Mack Hasz and Swain Molster. All rights reserved.
+//
+
+import XCTest
+@testable import Ward
+
+class WardTests: XCTestCase {
+    
+    // MARK: - Void Output
+    
+    // MARK: + () -> Void
+    
+    func testOneWardVoidToVoid() {
+        var counter = 0
+        
+        var sample: SampleClass? = SampleClass()
+        
+        let function: () -> Void = ward(sample.unsafelyUnwrapped) { _ in
+            counter += 1
+        }
+        
+        XCTAssert(counter == 0)
+        
+        function()
+        
+        XCTAssert(counter == 1)
+        
+        sample = nil
+        
+        function()
+        
+        XCTAssert(counter == 1)
+    }
+    
+    
+    func testTwoWardVoidToVoid() {
+        var counter = 0
+        
+        var sampleOne: SampleClass? = SampleClass()
+        var sampleTwo: SampleClass? = SampleClass()
+        
+        let function: () -> Void = ward(sampleOne.unsafelyUnwrapped, sampleTwo.unsafelyUnwrapped) { _, _ in
+            counter += 1
+        }
+        
+        XCTAssert(counter == 0)
+        
+        function()
+        
+        XCTAssert(counter == 1)
+        
+        sampleOne = nil
+        
+        function()
+        
+        XCTAssert(counter == 1)
+        
+        sampleTwo = nil
+        
+        function()
+        
+        XCTAssert(counter == 1)
+    }
+    
+    
+    func testThreeWardVoidToVoid() {
+        var counter = 0
+        
+        var sampleOne: SampleClass? = SampleClass()
+        var sampleTwo: SampleClass? = SampleClass()
+        var sampleThree: SampleClass? = SampleClass()
+        
+        let function: () -> Void = ward(sampleOne.unsafelyUnwrapped, sampleTwo.unsafelyUnwrapped, sampleThree.unsafelyUnwrapped) { _, _, _ in
+            counter += 1
+        }
+        
+        XCTAssert(counter == 0)
+        
+        function()
+        
+        XCTAssert(counter == 1)
+        
+        sampleOne = nil
+        
+        function()
+        
+        XCTAssert(counter == 1)
+        
+        sampleTwo = nil
+        
+        function()
+        
+        XCTAssert(counter == 1)
+        
+        sampleThree = nil
+        
+        function()
+        
+        XCTAssert(counter == 1)
+    }
+    
+    // MARK: + (A) -> Void
+    
+    func testOneWardAToVoid() {
+        var counter = 0
+        
+        var sample: SampleClass? = SampleClass()
+        
+        let function: (Bool) -> Void = ward(sample.unsafelyUnwrapped) { _, a in
+            let shouldInc = a
+            counter += shouldInc ? 1 : 0
+        }
+        
+        XCTAssert(counter == 0)
+        
+        function(true)
+        
+        XCTAssert(counter == 1)
+        
+        function(false)
+        
+        XCTAssert(counter == 1)
+        
+        sample = nil
+        
+        function(true)
+        
+        XCTAssert(counter == 1)
+    }
+    
+    func testTwoWardAToVoid() {
+        var counter = 0
+        
+        var sampleOne: SampleClass? = SampleClass()
+        var sampleTwo: SampleClass? = SampleClass()
+        
+        let function: (Bool) -> Void = ward(sampleOne.unsafelyUnwrapped, sampleTwo.unsafelyUnwrapped) { _, _, a in
+            let shouldInc = a
+            counter += shouldInc ? 1 : 0
+        }
+        
+        XCTAssert(counter == 0)
+        
+        function(true)
+        
+        XCTAssert(counter == 1)
+        
+        function(false)
+        
+        XCTAssert(counter == 1)
+        
+        sampleOne = nil
+        
+        function(true)
+        
+        XCTAssert(counter == 1)
+        
+        sampleTwo = nil
+        
+        function(true)
+        
+        XCTAssert(counter == 1)
+    }
+    
+    func testThreeWardAToVoid() {
+        var counter = 0
+        
+        var sampleOne: SampleClass? = SampleClass()
+        var sampleTwo: SampleClass? = SampleClass()
+        var sampleThree: SampleClass? = SampleClass()
+        
+        let function: (Bool) -> Void = ward(sampleOne.unsafelyUnwrapped, sampleTwo.unsafelyUnwrapped, sampleThree.unsafelyUnwrapped) { _, _, _, a in
+            let shouldInc = a
+            counter += shouldInc ? 1 : 0
+        }
+        
+        XCTAssert(counter == 0)
+        
+        function(true)
+        
+        XCTAssert(counter == 1)
+        
+        function(false)
+        
+        XCTAssert(counter == 1)
+        
+        sampleOne = nil
+        
+        function(true)
+        
+        XCTAssert(counter == 1)
+        
+        sampleTwo = nil
+        
+        function(true)
+        
+        XCTAssert(counter == 1)
+        
+        sampleThree = nil
+        
+        function(true)
+        
+        XCTAssert(counter == 1)
+    }
+    
+    // MARK: + (A, B) -> Void
+    
+    func testOneWardABToVoid() {
+        var counter = 0
+        
+        var sample: SampleClass? = SampleClass()
+        
+        let function: (Bool, Bool) -> Void = ward(sample.unsafelyUnwrapped) { _, a, b in
+            let shouldInc = a && b
+            counter += shouldInc ? 1 : 0
+        }
+        
+        XCTAssert(counter == 0)
+        
+        function(true, true)
+        
+        XCTAssert(counter == 1)
+        
+        function(false, true)
+        
+        XCTAssert(counter == 1)
+        
+        sample = nil
+        
+        function(true, true)
+        
+        XCTAssert(counter == 1)
+    }
+    
+    func testTwoWardABToVoid() {
+        var counter = 0
+        
+        var sampleOne: SampleClass? = SampleClass()
+        var sampleTwo: SampleClass? = SampleClass()
+        
+        let function: (Bool, Bool) -> Void = ward(sampleOne.unsafelyUnwrapped, sampleTwo.unsafelyUnwrapped) { _, _, a, b in
+            let shouldInc = a && b
+            counter += shouldInc ? 1 : 0
+        }
+        
+        XCTAssert(counter == 0)
+        
+        function(true, true)
+        
+        XCTAssert(counter == 1)
+        
+        function(false, true)
+        
+        XCTAssert(counter == 1)
+        
+        sampleOne = nil
+        
+        function(true, true)
+        
+        XCTAssert(counter == 1)
+        
+        sampleTwo = nil
+        
+        function(true, true)
+        
+        XCTAssert(counter == 1)
+    }
+    
+    func testThreeWardABToVoid() {
+        var counter = 0
+        
+        var sampleOne: SampleClass? = SampleClass()
+        var sampleTwo: SampleClass? = SampleClass()
+        var sampleThree: SampleClass? = SampleClass()
+        
+        let function: (Bool, Bool) -> Void = ward(sampleOne.unsafelyUnwrapped, sampleTwo.unsafelyUnwrapped, sampleThree.unsafelyUnwrapped) { _, _, _, a, b in
+            let shouldInc = a && b
+            counter += shouldInc ? 1 : 0
+        }
+        
+        XCTAssert(counter == 0)
+        
+        function(true, true)
+        
+        XCTAssert(counter == 1)
+        
+        function(false, true)
+        
+        XCTAssert(counter == 1)
+        
+        sampleOne = nil
+        
+        function(true, true)
+        
+        XCTAssert(counter == 1)
+        
+        sampleTwo = nil
+        
+        function(true, true)
+        
+        XCTAssert(counter == 1)
+        
+        sampleThree = nil
+        
+        function(true, true)
+        
+        XCTAssert(counter == 1)
+    }
+    
+    // MARK: + (A, B, C) -> Void
+    
+    func testOneWardABCToVoid() {
+        var counter = 0
+        
+        var sample: SampleClass? = SampleClass()
+        
+        let function: (Bool, Bool, Bool) -> Void = ward(sample.unsafelyUnwrapped) { _, a, b, c in
+            let shouldInc = a && b && c
+            counter += shouldInc ? 1 : 0
+        }
+        
+        XCTAssert(counter == 0)
+        
+        function(true, true, true)
+        
+        XCTAssert(counter == 1)
+        
+        function(false, true, true)
+        
+        XCTAssert(counter == 1)
+        
+        sample = nil
+        
+        function(true, true, true)
+        
+        XCTAssert(counter == 1)
+    }
+    
+    func testTwoWardABCToVoid() {
+        var counter = 0
+        
+        var sampleOne: SampleClass? = SampleClass()
+        var sampleTwo: SampleClass? = SampleClass()
+        
+        let function: (Bool, Bool, Bool) -> Void = ward(sampleOne.unsafelyUnwrapped, sampleTwo.unsafelyUnwrapped) { _, _, a, b, c in
+            let shouldInc = a && b && c
+            counter += shouldInc ? 1 : 0
+        }
+        
+        XCTAssert(counter == 0)
+        
+        function(true, true, true)
+        
+        XCTAssert(counter == 1)
+        
+        function(false, true, true)
+        
+        XCTAssert(counter == 1)
+        
+        sampleOne = nil
+        
+        function(true, true, true)
+        
+        XCTAssert(counter == 1)
+        
+        sampleTwo = nil
+        
+        function(true, true, true)
+        
+        XCTAssert(counter == 1)
+    }
+    
+    func testThreeWardABCToVoid() {
+        var counter = 0
+        
+        var sampleOne: SampleClass? = SampleClass()
+        var sampleTwo: SampleClass? = SampleClass()
+        var sampleThree: SampleClass? = SampleClass()
+        
+        let function: (Bool, Bool, Bool) -> Void = ward(sampleOne.unsafelyUnwrapped, sampleTwo.unsafelyUnwrapped, sampleThree.unsafelyUnwrapped) { _, _, _, a, b, c in
+            let shouldInc = a && b && c
+            counter += shouldInc ? 1 : 0
+        }
+        
+        XCTAssert(counter == 0)
+        
+        function(true, true, true)
+        
+        XCTAssert(counter == 1)
+        
+        function(false, true, true)
+        
+        XCTAssert(counter == 1)
+        
+        sampleOne = nil
+        
+        function(true, true, true)
+        
+        XCTAssert(counter == 1)
+        
+        sampleTwo = nil
+        
+        function(true, true, true)
+        
+        XCTAssert(counter == 1)
+        
+        sampleThree = nil
+        
+        function(true, true, true)
+        
+        XCTAssert(counter == 1)
+    }
+    
+    // MARK: - Generic Output
+    
+    // MARK: + () -> Z
+    
+    func testOneWardVoidToZ() {
+        var sample: SampleClass? = SampleClass()
+        
+        let function: () -> Bool = ward(sample.unsafelyUnwrapped, else: false) { _ in
+            return true
+        }
+        
+        XCTAssert(function() == true)
+        
+        sample = nil
+        
+        XCTAssert(function() == false)
+    }
+    
+    func testTwoWardVoidToZ() {
+        var sampleOne: SampleClass? = SampleClass()
+        var sampleTwo: SampleClass? = SampleClass()
+        
+        let function: () -> Bool = ward(sampleOne.unsafelyUnwrapped, sampleTwo.unsafelyUnwrapped, else: false) { _, _ in
+            return true
+        }
+        
+        XCTAssert(function() == true)
+        
+        sampleOne = nil
+        
+        XCTAssert(function() == false)
+        
+        sampleTwo = nil
+        
+        XCTAssert(function() == false)
+    }
+    
+    func testThreeWardVoidToZ() {
+        var sampleOne: SampleClass? = SampleClass()
+        var sampleTwo: SampleClass? = SampleClass()
+        var sampleThree: SampleClass? = SampleClass()
+        
+        let function: () -> Bool = ward(sampleOne.unsafelyUnwrapped, sampleTwo.unsafelyUnwrapped, sampleThree.unsafelyUnwrapped, else: false) { _, _, _ in
+            return true
+        }
+        
+        XCTAssert(function() == true)
+        
+        sampleOne = nil
+        
+        XCTAssert(function() == false)
+        
+        sampleTwo = nil
+        
+        XCTAssert(function() == false)
+        
+        sampleThree = nil
+        
+        XCTAssert(function() == false)
+    }
+    
+    // MARK: + (A) -> Z
+    
+    func testOneWardAToZ() {
+        var sample: SampleClass? = SampleClass()
+        
+        let function: (Int) -> Bool = ward(sample.unsafelyUnwrapped, else: false) { _, integer in
+            return integer % 2 == 0
+        }
+        
+        XCTAssert(function(2) == true)
+        
+        sample = nil
+        
+        XCTAssert(function(2) == false)
+    }
+    
+    func testTwoWardAToZ() {
+        var sampleOne: SampleClass? = SampleClass()
+        var sampleTwo: SampleClass? = SampleClass()
+        
+        let function: (Int) -> Bool = ward(sampleOne.unsafelyUnwrapped, sampleTwo.unsafelyUnwrapped, else: false) { _, _, integer in
+            return integer % 2 == 0
+        }
+        
+        XCTAssert(function(2) == true)
+        
+        sampleOne = nil
+        
+        XCTAssert(function(2) == false)
+        
+        sampleTwo = nil
+        
+        XCTAssert(function(2) == false)
+    }
+    
+    func testThreeWardAToZ() {
+        var sampleOne: SampleClass? = SampleClass()
+        var sampleTwo: SampleClass? = SampleClass()
+        var sampleThree: SampleClass? = SampleClass()
+        
+        let function: (Int) -> Bool = ward(sampleOne.unsafelyUnwrapped, sampleTwo.unsafelyUnwrapped, sampleThree.unsafelyUnwrapped, else: false) { _, _, _, integer in
+            return integer % 2 == 0
+        }
+        
+        XCTAssert(function(2) == true)
+        
+        sampleOne = nil
+        
+        XCTAssert(function(2) == false)
+        
+        sampleTwo = nil
+        
+        XCTAssert(function(2) == false)
+        
+        sampleThree = nil
+        
+        XCTAssert(function(2) == false)
+    }
+    
+    // MARK: + (A, B) -> Z
+    
+    func testOneWardABToZ() {
+        var sample: SampleClass? = SampleClass()
+        
+        let function: (Int, Int) -> Bool = ward(sample.unsafelyUnwrapped, else: false) { _, integer1, integer2 in
+            return (integer1 + integer2) % 2 == 0
+        }
+        
+        XCTAssert(function(2, 1) == false)
+        
+        XCTAssert(function(2, 2) == true)
+        
+        sample = nil
+        
+        XCTAssert(function(2, 2) == false)
+    }
+    
+    func testTwoWardABToZ() {
+        var sampleOne: SampleClass? = SampleClass()
+        var sampleTwo: SampleClass? = SampleClass()
+        
+        let function: (Int, Int) -> Bool = ward(sampleOne.unsafelyUnwrapped, sampleTwo.unsafelyUnwrapped, else: false) { _, _, integer1, integer2 in
+            return (integer1 + integer2) % 2 == 0
+        }
+        
+        XCTAssert(function(2, 2) == true)
+        
+        sampleOne = nil
+        
+        XCTAssert(function(2, 2) == false)
+        
+        sampleTwo = nil
+        
+        XCTAssert(function(2, 2) == false)
+    }
+    
+    func testThreeWardABToZ() {
+        var sampleOne: SampleClass? = SampleClass()
+        var sampleTwo: SampleClass? = SampleClass()
+        var sampleThree: SampleClass? = SampleClass()
+        
+        let function: (Int, Int) -> Bool = ward(sampleOne.unsafelyUnwrapped, sampleTwo.unsafelyUnwrapped, sampleThree.unsafelyUnwrapped, else: false) { _, _, _, integer1, integer2 in
+            return (integer1 + integer2) % 2 == 0
+        }
+        
+        XCTAssert(function(2, 2) == true)
+        
+        sampleOne = nil
+        
+        XCTAssert(function(2, 2) == false)
+        
+        sampleTwo = nil
+        
+        XCTAssert(function(2, 2) == false)
+        
+        sampleThree = nil
+        
+        XCTAssert(function(2, 2) == false)
+    }
+    
+    // MARK: + (A, B, C) -> Z
+    
+    func testOneWardABCToZ() {
+        var sample: SampleClass? = SampleClass()
+        
+        let function: (Int, Int, Int) -> Bool = ward(sample.unsafelyUnwrapped, else: false) { _, integer1, integer2, integer3 in
+            return (integer1 + integer2 + integer3) % 2 == 0
+        }
+        
+        XCTAssert(function(2, 2, 1) == false)
+        
+        XCTAssert(function(2, 2, 2) == true)
+        
+        sample = nil
+        
+        XCTAssert(function(2, 2, 2) == false)
+    }
+    
+    func testTwoWardABCToZ() {
+        var sampleOne: SampleClass? = SampleClass()
+        var sampleTwo: SampleClass? = SampleClass()
+        
+        let function: (Int, Int, Int) -> Bool = ward(sampleOne.unsafelyUnwrapped, sampleTwo.unsafelyUnwrapped, else: false) { _, _, integer1, integer2, integer3 in
+            return (integer1 + integer2 + integer3) % 2 == 0
+        }
+        
+        XCTAssert(function(2, 2, 1) == false)
+        
+        XCTAssert(function(2, 2, 2) == true)
+        
+        sampleOne = nil
+        
+        XCTAssert(function(2, 2, 2) == false)
+        
+        sampleTwo = nil
+        
+        XCTAssert(function(2, 2, 2) == false)
+    }
+    
+    func testThreeWardABCToZ() {
+        var sampleOne: SampleClass? = SampleClass()
+        var sampleTwo: SampleClass? = SampleClass()
+        var sampleThree: SampleClass? = SampleClass()
+        
+        let function: (Int, Int, Int) -> Bool = ward(sampleOne.unsafelyUnwrapped, sampleTwo.unsafelyUnwrapped, sampleThree.unsafelyUnwrapped, else: false) { _, _, _, integer1, integer2, integer3 in
+            return (integer1 + integer2 + integer3) % 2 == 0
+        }
+        
+        XCTAssert(function(2, 2, 1) == false)
+        
+        XCTAssert(function(2, 2, 2) == true)
+        
+        sampleOne = nil
+        
+        XCTAssert(function(2, 2, 2) == false)
+        
+        sampleTwo = nil
+        
+        XCTAssert(function(2, 2, 2) == false)
+        
+        sampleThree = nil
+        
+        XCTAssert(function(2, 2, 2) == false)
+    }
+}


### PR DESCRIPTION
This PR introduces non-API-breaking support for `ward`ing against up to three class references.

_Usage_
```swift
let aClass = MyClass()
let anotherClass = MyOtherClass()
let yetAnotherClass  = MyOtherOtherClass()

ward(aClass, anotherClass, yetAnotherClass) { first, second, third in 
    ...
}
```

Using multiple references will `ward` for the presence of **all** of the references.

e.g.
```swift
var aClass: MyClass? = MyClass()
let anotherClass = MyOtherClass()
let yetAnotherClass  = MyOtherOtherClass()

let function: () -> Bool = ward(
    aClass.unsafelyUnwrapped,
    anotherClass, 
    yetAnotherClass, 
    else: false
) { first, second, third in 
    return true
}

function() // true

aClass = nil

function() // false
```

Adding this feature required literally _tripling_ the number of functions (and test functions) in the framework (not ideal). Worth the cost, I'd say?